### PR TITLE
bug-WDP190403-4

### DIFF
--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -39,7 +39,7 @@
     }
     .price {
       .btn-main {
-        color: #ffffff !important;
+        color: #fff;
         background-color: $primary;
         text-decoration: none;
       }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -29,6 +29,20 @@
     .buttons {
       display: flex;
       justify-content: space-between;
+      visibility: hidden;
+    }
+  }
+
+  &:hover {
+    .buttons {
+      visibility: visible;
+    }
+    .price {
+      .btn-main {
+        color: #ffffff !important;
+        background-color: $primary;
+        text-decoration: none;
+      }
     }
   }
 


### PR DESCRIPTION
Zadanie: Buttony "Quick view" oraz "Add to cart" powinny być widoczne tylko na hover całego boksa z produktem. Wtedy też powinno zmieniać się tło ceny. 
Rozwiązanie:
Ukryłem button'y  "Quick view" oraz "Add to cart", następnie dodałem stan hover dla product-box gdzie ustawiłem ich widzialność, a także zmianę koloru tła ceny. 